### PR TITLE
clear_cart() fix

### DIFF
--- a/includes/api/class-wc-rest-cart-controller.php
+++ b/includes/api/class-wc-rest-cart-controller.php
@@ -213,6 +213,7 @@ class WC_REST_Cart_Controller {
 	 */
 	public function clear_cart() {
 		WC()->cart->empty_cart();
+		WC()->session->set('cart', array()); // Empty the session cart data
 
 		if ( WC()->cart->is_empty() ) {
 			return new WP_REST_Response( __( 'Cart is cleared.', 'cart-rest-api-for-woocommerce' ), 200 );


### PR DESCRIPTION
clear cart doesnt work if its a cart session.
This fixes it and makes sure the cart is cleared.

reference: https://stackoverflow.com/questions/47051472/woocommerce-empty-cart-functions-not-working