### PR TITLE
Allow removing of items via update logic if quantity is zero

### DIFF
--- a/includes/api/class-wc-rest-cart-controller.php
+++ b/includes/api/class-wc-rest-cart-controller.php
@@ -438,6 +438,10 @@ class WC_REST_Cart_Controller {
 		$cart_item_key = ! isset( $data['cart_item_key'] ) ? '0' : wc_clean( $data['cart_item_key'] );
 		$quantity      = ! isset( $data['quantity'] ) ? 1 : absint( $data['quantity'] );
 
+		if ( $quantity === 0 ) {
+			return $this->remove_item( $data );
+		}
+
 		$this->validate_quantity( $quantity );
 
 		if ( $cart_item_key != '0' ) {


### PR DESCRIPTION
When working with product bundles the update logic fails on the has_enough_stock logic.
This can be worked around by skipping the entire update logic if the goal is to remove the cart_item