### PR TITLE
V2.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.
 * NEW: Get a specific customers cart via their customer ID number. - See documentation for details.
 * NEW: Product title also returns besides just the product name when getting the cart.
+* NEW: Product price also returns when getting the cart.
 * Changed: Filter and Action Hook names in new API. - See documentation for details.
 * Improved: Complexity of functions for better performance and usage.
 * Tweaked: Added checking for items already in the cart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for CoCart
 
-## v2.0.0 - ?? June, 2019
+## v2.0.0 - 25th June, 2019
 
 * NEW: REST API namespace. CoCart is now an individual API and is no longer nested with WooCommerce's core REST API.
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@
 * Tweaked: Responses for adding, updating, removing and restoring items to return whole cart if requested.
 * Tweaked: Totals can now return once calculated if requested.
 * Tweaked: Totals now return from session and can be returned pre-formatted if requested. - See documentation for details.
+* Tweaked: New option to refresh cart totals once item has been added.
 * Dev: Added action hooks for getting cart, cart is cleared, item added, item removed and item restored.
 * Dev: Added filter to allow additional checks before the item is added to the cart.
 * Dev: Added filter to apply additional data to return when cart is returned.
 * Dev: Added filter to change the size of the thumbnail returned.
+* Dev: Added new option to return cart raw if requested.
 
 ## v1.2.3 - 7th June, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for CoCart
 
-## v2.0.0 - 25th June, 2019
+## v2.0.0 - ?? ??, 2019
 
 * NEW: REST API namespace. CoCart is now an individual API and is no longer nested with WooCommerce's core REST API.
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 **Tested up to:** 5.2.2  
 **WC requires at least:** 3.0.0  
 **WC tested up to:** 3.6.4  
-**Stable tag:** 2.0.0  
+**Stable tag:** 2.0.0-rc.1  
 **License:** GPL v2 or later  
 
 Control the cart via the REST-API for WooCommerce.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
 **Tags:** woocommerce, cart, endpoint, JSON, rest, api, REST API  
 **Requires at least:** 4.9.8  
 **Requires PHP:** 5.6  
-**Tested up to:** 5.2.1  
+**Tested up to:** 5.2.2  
 **WC requires at least:** 3.0.0  
 **WC tested up to:** 3.6.4  
-**Stable tag:** 1.2.3  
+**Stable tag:** 2.0.0  
 **License:** GPL v2 or later  
 
 Control the cart via the REST-API for WooCommerce.

--- a/assets/css/admin/cocart.css
+++ b/assets/css/admin/cocart.css
@@ -57,13 +57,11 @@
 .notice.cocart-notice h3 {
   margin: 0 0 5px; }
 
-.notice.cocart-notice .cocart-review-now,
-.notice.cocart-notice .cocart-send-feedback {
+.notice.cocart-notice .cocart-action {
   float: right;
   text-align: center; }
 
-.notice.cocart-notice .cocart-review-now .cocart-review-button,
-.notice.cocart-notice .cocart-send-feedback .cocart-feedback-button {
+.notice.cocart-notice .cocart-action .cocart-button {
   height: auto;
   line-height: 20px;
   padding: 6px 50px; }
@@ -89,7 +87,8 @@
     font-size: 0;
     width: 64px; }
 
-body.cocart-getting-started .notice {
+body.cocart-getting-started .notice,
+body.cocart-getting-started .error {
   display: none; }
 
 @media (max-width: 767px) {
@@ -102,8 +101,7 @@ body.cocart-getting-started .notice {
     padding: 0; }
   .notice.cocart-notice .cocart-notice-inner .cocart-notice-icon {
     display: none; }
-  .notice.cocart-notice .cocart-notice-inner .cocart-review-now,
-  .notice.cocart-notice .cocart-notice-inner .cocart-send-feedback {
+  .notice.cocart-notice .cocart-notice-inner .cocart-action {
     margin-top: 20px;
     display: block;
     text-align: left; }

--- a/assets/scss/admin/notices.scss
+++ b/assets/scss/admin/notices.scss
@@ -24,14 +24,12 @@
 			margin: 0 0 5px;
 		}
 
-		.cocart-review-now,
-		.cocart-send-feedback {
+		.cocart-action {
 			float: right;
 			text-align: center;
 		}
 
-		.cocart-review-now .cocart-review-button,
-		.cocart-send-feedback .cocart-feedback-button {
+		.cocart-action .cocart-button {
 			height: auto;
 			line-height: 20px;
 			padding: 6px 50px;
@@ -67,7 +65,8 @@
 	}
 }
 
-body.cocart-getting-started .notice {
+body.cocart-getting-started .notice,
+body.cocart-getting-started .error {
 	display: none;
 }
 
@@ -89,8 +88,7 @@ body.cocart-getting-started .notice {
 		display: none;
 	}
 
-	.notice.cocart-notice .cocart-notice-inner .cocart-review-now,
-	.notice.cocart-notice .cocart-notice-inner .cocart-send-feedback {
+	.notice.cocart-notice .cocart-notice-inner .cocart-action {
 		margin-top: 20px;
 		display: block;
 		text-align: left;

--- a/cart-rest-api-for-woocommerce.php
+++ b/cart-rest-api-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides additional REST-API endpoints for WooCommerce to enable the ability to add, view, update and delete items from the cart.
  * Author:      Sébastien Dumont
  * Author URI:  https://sebastiendumont.com
- * Version:     2.0.0-beta.2
+ * Version:     2.0.0
  * Text Domain: cart-rest-api-for-woocommerce
  * Domain Path: /languages/
  *
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CoCart' ) ) {
 		 * @static
 		 * @since  1.0.0
 		 */
-		public static $version = '2.0.0-beta.2';
+		public static $version = '2.0.0';
 
 		/**
 		 * Required WooCommerce Version

--- a/cart-rest-api-for-woocommerce.php
+++ b/cart-rest-api-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides additional REST-API endpoints for WooCommerce to enable the ability to add, view, update and delete items from the cart.
  * Author:      Sébastien Dumont
  * Author URI:  https://sebastiendumont.com
- * Version:     2.0.0
+ * Version:     2.0.0-rc.1
  * Text Domain: cart-rest-api-for-woocommerce
  * Domain Path: /languages/
  *
@@ -37,7 +37,7 @@ if ( ! class_exists( 'CoCart' ) ) {
 		 * @static
 		 * @since  1.0.0
 		 */
-		public static $version = '2.0.0';
+		public static $version = '2.0.0-rc.1';
 
 		/**
 		 * Required WooCommerce Version

--- a/includes/admin/views/html-notice-please-review.php
+++ b/includes/admin/views/html-notice-please-review.php
@@ -30,8 +30,8 @@ $time = CoCart_Admin::cocart_seconds_to_words( time() - $install_date );
 			<p><?php printf( esc_html__( 'You have been using %1$s for %2$s now! Mind leaving a review and let me know know what you think of the plugin? I\'d really appreciate it!', 'cart-rest-api-for-woocommerce' ), 'CoCart', esc_html( $time ) ); ?></p>
 		</div>
 
-		<div class="cocart-review-now">
-			<?php printf( '<a href="%1$s" class="button button-primary cocart-review-button" aria-label="' . esc_html__( 'Leave a Review', 'cart-rest-api-for-woocommerce' ) . '" target="_blank">%2$s</a>', esc_url( COCART_REVIEW_URL . '?rate=5#new-post' ), esc_html__( 'Leave a Review', 'cart-rest-api-for-woocommerce' ) ); ?>
+		<div class="cocart-action">
+			<?php printf( '<a href="%1$s" class="button button-primary cocart-button" aria-label="' . esc_html__( 'Leave a Review', 'cart-rest-api-for-woocommerce' ) . '" target="_blank">%2$s</a>', esc_url( COCART_REVIEW_URL . '?rate=5#new-post' ), esc_html__( 'Leave a Review', 'cart-rest-api-for-woocommerce' ) ); ?>
 			<a href="<?php echo esc_url( add_query_arg( 'hide_cocart_review_notice', 'true' ) ); ?>" class="no-thanks" aria-label="<?php echo esc_html__( 'Hide Review Notice', 'cart-rest-api-for-woocommerce' ); ?>"><?php echo esc_html__( 'No thank you / I already have', 'cart-rest-api-for-woocommerce' ); ?></a>
 		</div>
 	</div>

--- a/includes/admin/views/html-notice-required-wc.php
+++ b/includes/admin/views/html-notice-required-wc.php
@@ -26,10 +26,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 
 		<?php if ( current_user_can( 'update_plugins' ) ) { ?>
-		<div class="cocart-review-now">
+		<div class="cocart-action">
 			<?php $upgrade_url = wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=woocommerce' ), 'upgrade-plugin_woocommerce' ); ?>
 
-			<p><a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary cocart-review-button" aria-label="<?php echo esc_html__( 'Update WooCommerce', 'cart-rest-api-for-woocommerce' ); ?>"><?php echo esc_html__( 'Update WooCommerce', 'cart-rest-api-for-woocommerce' ); ?></a></p>
+			<p><a href="<?php echo esc_url( $upgrade_url ); ?>" class="button button-primary cocart-button" aria-label="<?php echo esc_html__( 'Update WooCommerce', 'cart-rest-api-for-woocommerce' ); ?>"><?php echo esc_html__( 'Update WooCommerce', 'cart-rest-api-for-woocommerce' ); ?></a></p>
 		</div>
 		<?php } ?>
 	</div>

--- a/includes/admin/views/html-notice-trying-beta.php
+++ b/includes/admin/views/html-notice-trying-beta.php
@@ -26,8 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p><?php echo esc_html__( 'If you have any questions or any feedback at all, please let me know. Any little bit you\'re willing to share helps.', 'cart-rest-api-for-woocommerce' ); ?></p>
 		</div>
 
-		<div class="cocart-send-feedback">
-			<?php printf( '<a href="%1$s" class="button button-primary cocart-feedback-button" aria-label="' . esc_html__( 'Give Feedback for %2$s', 'cart-rest-api-for-woocommerce' ) . '" target="_blank">%3$s</a>', esc_url( COCART_STORE_URL . 'feedback/' ), 'CoCart', esc_html__( 'Give Feedback', 'cart-rest-api-for-woocommerce' ) ); ?>
+		<div class="cocart-action">
+			<?php printf( '<a href="%1$s" class="button button-primary cocart-button" aria-label="' . esc_html__( 'Give Feedback for %2$s', 'cart-rest-api-for-woocommerce' ) . '" target="_blank">%3$s</a>', esc_url( COCART_STORE_URL . 'feedback/' ), 'CoCart', esc_html__( 'Give Feedback', 'cart-rest-api-for-woocommerce' ) ); ?>
 			<a href="<?php echo esc_url( add_query_arg( 'hide_cocart_beta_notice', 'true' ) ); ?>" class="no-thanks" aria-label="<?php echo esc_html__( 'Hide this notice and ask me again for feedback in 7 days', 'cart-rest-api-for-woocommerce' ); ?>"><?php echo esc_html__( 'Ask me again in 7 days', 'cart-rest-api-for-woocommerce' ); ?></a>
 		</div>
 	</div>

--- a/includes/admin/views/html-notice-upgrade-warning.php
+++ b/includes/admin/views/html-notice-upgrade-warning.php
@@ -25,8 +25,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p><?php echo sprintf( __( 'Version %1$s2.0.0%2$s of %3$s is coming soon and will provide a new and improved API. Before it is released, I require your help to test it out and provide your feedback!', 'cart-rest-api-for-woocommerce' ), '<strong>', '</strong>', 'CoCart' ); ?></p>
 		</div>
 
-		<div class="cocart-send-feedback">
-			<?php printf( '<a href="%1$s" class="button button-primary cocart-feedback-button" target="_blank">%2$s</a>', esc_url( 'https://cocart.xyz/cocart-v2-preview/' ), esc_html__( 'Learn More', 'cart-rest-api-for-woocommerce' ) ); ?>
+		<div class="cocart-action">
+			<?php printf( '<a href="%1$s" class="button button-primary cocart-button" target="_blank">%2$s</a>', esc_url( 'https://cocart.xyz/cocart-v2-preview/' ), esc_html__( 'Learn More', 'cart-rest-api-for-woocommerce' ) ); ?>
 			<a href="<?php echo esc_url( add_query_arg( 'hide_cocart_upgrade_notice', 'true' ) ); ?>" class="no-thanks"><?php echo esc_html__( 'Ask me again in 2 weeks', 'cart-rest-api-for-woocommerce' ); ?></a>
 		</div>
 	</div>

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -296,6 +296,9 @@ class CoCart_API_Controller {
 			$cart_contents[$item_key]['product_name']  = $_product->get_name();
 			$cart_contents[$item_key]['product_title'] = $_product->get_title();
 
+			// Add product price as a new variable.
+			$cart_contents[$item_key]['product_price'] = html_entity_decode( strip_tags( wc_price( $_product->get_price() ) ) );
+
 			// If main product thumbnail is requested then add it to each item in cart.
 			if ( $show_thumb ) {
 				$thumbnail_id = apply_filters( 'cocart_item_thumbnail', $_product->get_image_id(), $cart_item, $item_key );

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -457,7 +457,7 @@ class CoCart_API_Controller {
 	 */
 	public function find_product_in_cart( $cart_id = false ) {
 		if ( false !== $cart_id ) {
-			if ( is_array( WC()->cart->get_cart() ) && null !== WC()->cart->get_cart( array(), $cart_id ) ) {
+			if ( is_array( self::get_cart() ) && null !== self::get_cart( array(), $cart_id ) ) {
 				return $cart_id;
 			}
 		}

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -222,12 +222,19 @@ class CoCart_API_Controller {
 	 * @version 2.0.0
 	 * @param   array  $data
 	 * @param   string $item_key
-	 * @return  WP_REST_Response
+	 * @return  array|WP_REST_Response
 	 */
 	public function get_cart( $data = array(), $item_key = '0' ) {
 		$cart_contents = $this->get_cart_contents( $data, $item_key );
 
 		do_action( 'cocart_get_cart', $cart_contents );
+
+		$show_raw = ! empty( $data['raw'] ) ? $data['raw'] : false;
+
+		// Return cart contents raw if requested.
+		if ( $show_raw ) {
+			return $cart_contents;
+		}
 
 		return new WP_REST_Response( $cart_contents, 200 );
 	} // END get_cart()

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -47,16 +47,19 @@ class CoCart_API_Controller {
 			'callback' => array( $this, 'add_to_cart' ),
 			'args'     => array(
 				'product_id' => array(
+					'description'       => __( 'Unique identifier for the product ID.', 'cart-rest-api-for-woocommerce' ),
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
 				),
 				'quantity' => array(
+					'description'       => __( 'The quantity amount of the item to add to cart.', 'cart-rest-api-for-woocommerce' ),
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
 				),
 				'variation_id' => array(
+					'description'       => __( 'Unique identifier for the variation ID.', 'cart-rest-api-for-woocommerce' ),
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
@@ -110,7 +113,9 @@ class CoCart_API_Controller {
 			'callback' => array( $this, 'get_cart' ),
 			'args'     => array(
 				'thumb' => array(
-					'default' => false,
+					'description' => __( 'Returns the URL of the product image thumbnail.', 'cart-rest-api-for-woocommerce' ),
+					'default'     => false,
+					'type'        => 'boolean',
 				),
 			),
 		));
@@ -127,7 +132,9 @@ class CoCart_API_Controller {
 					'type'        => 'integer',
 				),
 				'thumb' => array(
-					'default' => false,
+					'description' => __( 'Returns the URL of the product image thumbnail.', 'cart-rest-api-for-woocommerce' ),
+					'default'     => false,
+					'type'        => 'boolean',
 				),
 			),
 		));
@@ -136,7 +143,7 @@ class CoCart_API_Controller {
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/item', array(
 			'args' => array(
 				'cart_item_key' => array(
-					'description' => __( 'The cart item key is what identifies the item in the cart.', 'cart-rest-api-for-woocommerce' ),
+					'description' => __( 'Unique identifier for the item in the cart.', 'cart-rest-api-for-woocommerce' ),
 					'type'        => 'string',
 				),
 				'return_cart' => array(

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -462,7 +462,8 @@ class CoCart_API_Controller {
 		$quantity = absint( $quantity );
 
 		if ( ! $current_product->has_enough_stock( $quantity ) ) {
-			return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'cart-rest-api-for-woocommerce' ), $current_product->get_name(), wc_format_stock_quantity_for_display( $current_product->get_stock_quantity(), $current_product ) ), array( 'status' => 500 ) );
+			/* translators: 1: quantity requested, 2: product name 3: quantity in stock */
+			return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add a quantity of %1$s for "%2$s" to the cart because there is not enough stock. - only %3$s remaining!', 'cart-rest-api-for-woocommerce' ), $quantity, $current_product->get_name(), wc_format_stock_quantity_for_display( $current_product->get_stock_quantity(), $current_product ) ), array( 'status' => 500 ) );
 		}
 
 		return true;
@@ -516,12 +517,13 @@ class CoCart_API_Controller {
 
 		// Stock check - only check if we're managing stock and backorders are not allowed.
 		if ( ! $product_data->is_in_stock() ) {
-			return new WP_Error( 'cocart_product_out_of_stock', sprintf( __( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
+			/* translators: %s: product name */
+			return new WP_Error( 'cocart_product_out_of_stock', sprintf( __( 'You cannot add "%s" to the cart because the product is out of stock.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
 		}
 
 		if ( ! $product_data->has_enough_stock( $quantity ) ) {
-			/* translators: 1: product name 2: quantity in stock */
-			return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'cart-rest-api-for-woocommerce' ), $product_data->get_name(), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ) ), array( 'status' => 500 ) );
+			/* translators: 1: quantity requested, 2: product name, 3: quantity in stock */
+			return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add a quantity of %1$s for "%2$s" to the cart because there is not enough stock. - only %3$s remaining!', 'cart-rest-api-for-woocommerce' ), $quantity, $product_data->get_name(), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ) ), array( 'status' => 500 ) );
 		}
 
 		// Stock check - this time accounting for whats already in-cart.
@@ -529,6 +531,7 @@ class CoCart_API_Controller {
 			$products_qty_in_cart = WC()->cart->get_cart_item_quantities();
 
 			if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
+				/* translators: 1: quantity in stock, 2: quantity in cart */
 				return new WP_Error(
 					'cocart_not_enough_stock_remaining',
 					sprintf(
@@ -575,6 +578,7 @@ class CoCart_API_Controller {
 				return new WP_REST_Response( $item_added, 200 );
 			}
 		} else {
+			/* translators: %s: product name */
 			return new WP_Error( 'cocart_cannot_add_to_cart', sprintf( __( 'You cannot add "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
 		}
 	} // END add_to_cart()
@@ -699,10 +703,13 @@ class CoCart_API_Controller {
 
 				// Return response based on product quantity increment.
 				if ( $quantity > $current_data['quantity'] ) {
+					/* translators: 1: product name, 2: new quantity */
 					return new WP_REST_Response( sprintf( __( 'The quantity for "%1$s" has increased to "%2$s".', 'cart-rest-api-for-woocommerce' ), $product_data->get_name(), $new_data['quantity'] ), 200 );
 				} else if ( $quantity < $current_data['quantity'] ) {
+					/* translators: 1: product name, 2: new quantity */
 					return new WP_REST_Response( sprintf( __( 'The quantity for "%1$s" has decreased to "%2$s".', 'cart-rest-api-for-woocommerce' ), $product_data->get_name(), $new_data['quantity'] ), 200 );
 				} else {
+					/* translators: %s: product name */
 					return new WP_REST_Response( sprintf( __( 'The quantity for "%s" has not changed.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), 200 );
 				}
 			} else {

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -48,18 +48,22 @@ class CoCart_API_Controller {
 			'args'     => array(
 				'product_id' => array(
 					'description'       => __( 'Unique identifier for the product ID.', 'cart-rest-api-for-woocommerce' ),
+					'type'              => 'integer',
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
 				),
 				'quantity' => array(
 					'description'       => __( 'The quantity amount of the item to add to cart.', 'cart-rest-api-for-woocommerce' ),
+					'default'           => 1,
+					'type'              => 'integer',
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
 				),
 				'variation_id' => array(
 					'description'       => __( 'Unique identifier for the variation ID.', 'cart-rest-api-for-woocommerce' ),
+					'type'              => 'integer',
 					'validate_callback' => function( $param, $request, $key ) {
 						return is_numeric( $param );
 					}
@@ -83,9 +87,9 @@ class CoCart_API_Controller {
 			'callback' => array( $this, 'calculate_totals' ),
 			'args'     => array(
 				'return' => array(
-					'validate_callback' => function( $param, $request, $key ) {
-						return is_bool( $param );
-					}
+					'default'     => false,
+					'description' => __( 'Returns the cart totals once calculated.', 'cart-rest-api-for-woocommerce' ),
+					'type'        => 'boolean',
 				)
 			)
 		));
@@ -147,11 +151,9 @@ class CoCart_API_Controller {
 					'type'        => 'string',
 				),
 				'return_cart' => array(
-					'description'       => __( 'Returns the whole cart if requested.', 'cart-rest-api-for-woocommerce' ),
-					'default'           => false,
-					'validate_callback' => function( $param, $request, $key ) {
-						return is_bool( $param );
-					}
+					'description' => __( 'Returns the whole cart to reduce requests.', 'cart-rest-api-for-woocommerce' ),
+					'default'     => false,
+					'type'        => 'boolean',
 				)
 			),
 			array(
@@ -182,7 +184,11 @@ class CoCart_API_Controller {
 			'callback' => array( $this, 'get_totals' ),
 			'args'     => array(
 				'html' => array(
-					'default' => false,
+					'default'           => false,
+					'type'              => 'boolean',
+					'validate_callback' => function( $param, $request, $key ) {
+						return is_bool( $param );
+					}
 				),
 			),
 		));
@@ -578,7 +584,7 @@ class CoCart_API_Controller {
 			do_action( 'cocart_item_added_to_cart', $item_key, $item_added );
 
 			// Was it requested to return the whole cart once item added?
-			if ( isset( $data['return_cart'] ) ) {
+			if ( $data['return_cart'] ) {
 				$cart_contents = $this->get_cart_contents( $data );
 
 				return new WP_REST_Response( $cart_contents, 200 );
@@ -617,7 +623,7 @@ class CoCart_API_Controller {
 				do_action( 'cocart_item_removed', $current_data );
 
 				// Was it requested to return the whole cart once item removed?
-				if ( isset( $data['return_cart'] ) ) {
+				if ( $data['return_cart'] ) {
 					$cart_contents = $this->get_cart_contents( $data );
 
 					return new WP_REST_Response( $cart_contents, 200 );
@@ -651,7 +657,7 @@ class CoCart_API_Controller {
 				do_action( 'cocart_item_restored', $current_data );
 
 				// Was it requested to return the whole cart once item restored?
-				if ( isset( $data['return_cart'] ) ) {
+				if ( $data['return_cart'] ) {
 					$cart_contents = $this->get_cart_contents( $data );
 
 					return new WP_REST_Response( $cart_contents, 200 );
@@ -705,7 +711,7 @@ class CoCart_API_Controller {
 				}
 
 				// Was it requested to return the whole cart once item updated?
-				if ( isset( $data['return_cart'] ) ) {
+				if ( $data['return_cart'] ) {
 					$cart_contents = $this->get_cart_contents( $data );
 
 					return new WP_REST_Response( $cart_contents, 200 );
@@ -746,7 +752,8 @@ class CoCart_API_Controller {
 
 		WC()->cart->calculate_totals();
 
-		if ( isset( $data['return'] ) ) {
+		// Was it requested to return all totals once calculated?
+		if ( $data['return'] ) {
 			return $this->get_totals( $data );
 		}
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -779,7 +779,7 @@ class CoCart_API_Controller {
 				}
 			}
 
-			return new WP_REST_Response( $new_totals, 200 );
+			$totals = $new_totals;
 		}
 
 		return new WP_REST_Response( $totals, 200 );

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -503,6 +503,12 @@ class CoCart_API_Controller {
 
 		$this->validate_product( $product_id, $quantity );
 
+		// Ensure we don't add a variation to the cart directly by variation ID.
+		if ( 'product_variation' === get_post_type( $product_id ) ) {
+			$variation_id = $product_id;
+			$product_id   = wp_get_post_parent_id( $variation_id );
+		}
+
 		$product_data = wc_get_product( $variation_id ? $variation_id : $product_id );
 
 		if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -186,7 +186,7 @@ class CoCart_API_Controller {
 	 *
 	 * @access public
 	 * @since  2.0.0
-	 * @return bool|WP_ERROR
+	 * @return bool|WP_Error
 	 */
 	public function get_permission_check() {
 		if ( ! current_user_can( 'administrator' ) ) {
@@ -221,7 +221,7 @@ class CoCart_API_Controller {
 	 * @since  2.0.0
 	 * @param  array $data
 	 * @param  string $item_key
-	 * @return array|WP_ERROR
+	 * @return array|WP_Error
 	 */
 	public function get_cart_customer( $data = array(), $item_key = '0' ) {
 		if ( empty( $data['id'] ) ) {
@@ -362,7 +362,7 @@ class CoCart_API_Controller {
 	 * @access  public
 	 * @since   1.0.0
 	 * @version 2.0.0
-	 * @return  WP_ERROR|WP_REST_Response
+	 * @return  WP_Error|WP_REST_Response
 	 */
 	public function clear_cart() {
 		WC()->cart->empty_cart();
@@ -611,10 +611,10 @@ class CoCart_API_Controller {
 
 				return new WP_REST_Response( __( 'Item has been removed from cart.', 'cart-rest-api-for-woocommerce' ), 200 );
 			} else {
-				return new WP_ERROR( 'cocart_can_not_remove_item', __( 'Unable to remove item from cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'cocart_can_not_remove_item', __( 'Unable to remove item from cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 			}
 		} else {
-			return new WP_ERROR( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+			return new WP_Error( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 	} // END remove_item()
 
@@ -645,10 +645,10 @@ class CoCart_API_Controller {
 
 				return new WP_REST_Response( __( 'Item has been restored to the cart.', 'cart-rest-api-for-woocommerce' ), 200 );
 			} else {
-				return new WP_ERROR( 'cocart_can_not_restore_item', __( 'Unable to restore item to the cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'cocart_can_not_restore_item', __( 'Unable to restore item to the cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 			}
 		} else {
-			return new WP_ERROR( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+			return new WP_Error( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 	} // END restore_item()
 
@@ -706,10 +706,10 @@ class CoCart_API_Controller {
 					return new WP_REST_Response( sprintf( __( 'The quantity for "%s" has not changed.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), 200 );
 				}
 			} else {
-				return new WP_ERROR( 'cocart_can_not_update_item', __( 'Unable to update item quantity in cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+				return new WP_Error( 'cocart_can_not_update_item', __( 'Unable to update item quantity in cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 			}
 		} else {
-			return new WP_ERROR( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+			return new WP_Error( 'cocart_cart_item_key_required', __( 'Cart item key is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 	} // END update_item()
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -219,11 +219,11 @@ class CoCart_API_Controller {
 	 * @since   1.0.0
 	 * @version 2.0.0
 	 * @param   array  $data
-	 * @param   string $item_key
+	 * @param   string $cart_item_key
 	 * @return  array|WP_REST_Response
 	 */
-	public function get_cart( $data = array(), $item_key = '0' ) {
-		$cart_contents = $this->get_cart_contents( $data, $item_key );
+	public function get_cart( $data = array(), $cart_item_key = '' ) {
+		$cart_contents = $this->get_cart_contents( $data, $cart_item_key );
 
 		do_action( 'cocart_get_cart', $cart_contents );
 
@@ -242,11 +242,11 @@ class CoCart_API_Controller {
 	 *
 	 * @access public
 	 * @since  2.0.0
-	 * @param  array $data
-	 * @param  string $item_key
+	 * @param  array  $data
+	 * @param  string $cart_item_key
 	 * @return array|WP_Error
 	 */
-	public function get_cart_customer( $data = array(), $item_key = '0' ) {
+	public function get_cart_customer( $data = array(), $cart_item_key = '' ) {
 		if ( empty( $data['id'] ) ) {
 			return new WP_Error( 'cocart_customer_missing', __( 'Customer ID is required!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 		}
@@ -255,10 +255,10 @@ class CoCart_API_Controller {
 
 		// If a saved cart exists then replace the carts content.
 		if ( ! empty( $saved_cart ) ) {
-			return $this->return_cart_contents( $saved_cart, $data, $item_key );
+			return $this->return_cart_contents( $saved_cart, $data, $cart_item_key );
 		}
 
-		return $this->get_cart_contents( $data, $item_key );
+		return $this->get_cart_contents( $data, $cart_item_key );
 	} // END get_cart_customer()
 
 	/**
@@ -267,13 +267,13 @@ class CoCart_API_Controller {
 	 * @access public
 	 * @since  2.0.0
 	 * @param  array  $data
-	 * @param  string $item_key
+	 * @param  string $cart_item_key
 	 * @return array  $cart_contents
 	 */
-	public function get_cart_contents( $data = array(), $item_key = '0' ) {
+	public function get_cart_contents( $data = array(), $cart_item_key = '' ) {
 		$cart_contents = isset( WC()->cart ) ? WC()->cart->get_cart() : WC()->session->cart;
 
-		return $this->return_cart_contents( $cart_contents, $data, $item_key );
+		return $this->return_cart_contents( $cart_contents, $data, $cart_item_key );
 	} // END get_cart_contents()
 
 	/**
@@ -283,10 +283,10 @@ class CoCart_API_Controller {
 	 * @since  2.0.0
 	 * @param  array  $cart_contents
 	 * @param  array  $data
-	 * @param  string $item_key
+	 * @param  string $cart_item_key
 	 * @return array  $cart_contents
 	 */
-	public function return_cart_contents( $cart_contents, $data = array(), $item_key = '0' ) {
+	public function return_cart_contents( $cart_contents, $data = array(), $cart_item_key = '' ) {
 		if ( $this->get_cart_contents_count( array( 'return' => 'numeric' ) ) <= 0 || empty( $cart_contents ) ) {
 			return array();
 		}
@@ -451,19 +451,19 @@ class CoCart_API_Controller {
 	} // END validate_product()
 
 	/**
-	 * Check if product is in the cart and return cart item key.
+	 * Check if product is in the cart and return cart item key if found.
 	 *
 	 * Cart item key will be unique based on the item and its properties, such as variations.
 	 *
 	 * @access public
 	 * @since  2.0.0
-	 * @param  mixed  $cart_id id of product to find in the cart.
-	 * @return string cart item key
+	 * @param  string $cart_item_key of product to find in the cart.
+	 * @return string Returns the same cart item key if valid.
 	 */
-	public function find_product_in_cart( $cart_id = false ) {
-		if ( false !== $cart_id ) {
-			if ( is_array( self::get_cart() ) && null !== self::get_cart( array(), $cart_id ) ) {
-				return $cart_id;
+	public function find_product_in_cart( $cart_item_key = '' ) {
+		if ( ! empty( $cart_item_key ) ) {
+			if ( is_array( self::get_cart() ) && null !== self::get_cart( array(), $cart_item_key ) ) {
+				return $cart_item_key;
 			}
 		}
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -150,6 +150,11 @@ class CoCart_API_Controller {
 					'description' => __( 'Unique identifier for the item in the cart.', 'cart-rest-api-for-woocommerce' ),
 					'type'        => 'string',
 				),
+				'refresh_totals' => array(
+					'description' => __( 'Re-calculates the totals once item has been added or the quantity of the item has increased.', 'cart-rest-api-for-woocommerce' ),
+					'default'     => false,
+					'type'        => 'boolean',
+				),
 				'return_cart' => array(
 					'description' => __( 'Returns the whole cart to reduce requests.', 'cart-rest-api-for-woocommerce' ),
 					'default'     => false,
@@ -588,6 +593,11 @@ class CoCart_API_Controller {
 
 		// Return response to added item to cart or return error.
 		if ( $item_key ) {
+				// Re-calculate cart totals once item has been added.
+				if ( $data['refresh_totals'] ) {
+					WC()->cart->calculate_totals();
+				}
+
 			$item_added = WC()->cart->get_cart_item( $item_key );
 
 			do_action( 'cocart_item_added_to_cart', $item_key, $item_added );

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -515,6 +515,9 @@ class CoCart_API_Controller {
 			return new WP_Error( 'cocart_product_does_not_exist', __( 'Warning: This product does not exist!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
 		}
 
+		// Generate a ID based on product ID, variation ID, variation data, and other cart item data.
+		$cart_id = WC()->cart->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
+
 		// Find the cart item key in the existing cart.
 		$cart_item_key = $this->find_product_in_cart( $cart_id );
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -617,7 +617,13 @@ class CoCart_API_Controller {
 		}
 
 		if ( $cart_item_key != '0' ) {
-			$current_data = WC()->cart->get_cart_item( $cart_item_key ); // Fetches the cart item data before it is removed.
+			// Check item exists in cart before fetching the cart item data to update.
+			$current_data = WC()->cart->get_cart_item( $cart_item_key );
+
+			// If item does not exist in cart return response.
+			if ( empty( $current_data ) ) {
+				return new WP_Error( 'cocart_item_not_in_cart', __( 'Item specified does not exist in cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 404 ) );
+			}
 
 			if ( WC()->cart->remove_cart_item( $cart_item_key ) ) {
 				do_action( 'cocart_item_removed', $current_data );
@@ -693,7 +699,13 @@ class CoCart_API_Controller {
 		$this->validate_quantity( $quantity );
 
 		if ( $cart_item_key != '0' ) {
-			$current_data = WC()->cart->get_cart_item( $cart_item_key ); // Fetches the cart item data before it is updated.
+			// Check item exists in cart before fetching the cart item data to update.
+			$current_data = WC()->cart->get_cart_item( $cart_item_key );
+
+			// If item does not exist in cart return response.
+			if ( empty( $current_data ) ) {
+				return new WP_Error( 'cocart_item_not_in_cart', __( 'Item specified does not exist in cart.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 404 ) );
+			}
 
 			$this->has_enough_stock( $current_data, $quantity ); // Checks if the item has enough stock before updating.
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -476,18 +476,17 @@ class CoCart_API_Controller {
 	 * Checks if the product in the cart has enough stock 
 	 * before updating the quantity.
 	 * 
-	 * @access protected
-	 * @since  1.0.6
-	 * @param  array  $current_data
-	 * @param  string $quantity
-	 * @return bool|WP_Error
+	 * @access  protected
+	 * @since   1.0.6
+	 * @version 2.0.0
+	 * @param   array  $current_data
+	 * @param   string $quantity
+	 * @return  bool|WP_Error
 	 */
 	protected function has_enough_stock( $current_data = array(), $quantity = 1 ) {
 		$product_id      = ! isset( $current_data['product_id'] ) ? 0 : absint( $current_data['product_id'] );
 		$variation_id    = ! isset( $current_data['variation_id'] ) ? 0 : absint( $current_data['variation_id'] );
 		$current_product = wc_get_product( $variation_id ? $variation_id : $product_id );
-
-		$quantity = absint( $quantity );
 
 		if ( ! $current_product->has_enough_stock( $quantity ) ) {
 			/* translators: 1: quantity requested, 2: product name 3: quantity in stock */

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -628,9 +628,7 @@ class CoCart_API_Controller {
 		// Was it requested to return the whole cart once item added?
 		if ( $data['return_cart'] ) {
 			$response = $this->get_cart_contents( $data );
-		}
-
-		if ( is_array( $item_added ) ) {
+		} else if ( is_array( $item_added ) ) {
 			$response = $item_added;
 		}
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -293,17 +293,11 @@ class CoCart_API_Controller {
 
 		$show_thumb = ! empty( $data['thumb'] ) ? $data['thumb'] : false;
 
-		// Used to check if the item exists in the cart with `find_product_in_cart()` function.
-		if ( ! empty( $item_key ) && $item_key != '0' ) {
-			$does_item_exist = $cart_contents[$item_key];
+		// Find the cart item key in the existing cart.
+		if ( ! empty( $cart_item_key ) ) {
+			$cart_item_key = $this->find_product_in_cart( $cart_item_key );
 
-			// If the data does not return empty then the item is in cart.
-			if ( ! empty( $does_item_exist ) ) {
-				return true;
-			}
-			else {
-				return false;
-			}
+			return $cart_contents[$cart_item_key];
 		}
 
 		foreach ( $cart_contents as $item_key => $cart_item ) {

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -628,12 +628,12 @@ class CoCart_API_Controller {
 
 		$response = '';
 
-			// Was it requested to return the whole cart once item added?
-			if ( $data['return_cart'] ) {
+		// Was it requested to return the whole cart once item added?
+		if ( $data['return_cart'] ) {
 			$response = $this->get_cart_contents( $data );
-			}
+		}
 
-			if ( is_array( $item_added ) ) {
+		if ( is_array( $item_added ) ) {
 			$response = $item_added;
 		}
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -189,11 +189,9 @@ class CoCart_API_Controller {
 			'callback' => array( $this, 'get_totals' ),
 			'args'     => array(
 				'html' => array(
-					'default'           => false,
-					'type'              => 'boolean',
-					'validate_callback' => function( $param, $request, $key ) {
-						return is_bool( $param );
-					}
+					'description' => __( 'Returns the totals pre-formatted.', 'cart-rest-api-for-woocommerce' ),
+					'default' => false,
+					'type'    => 'boolean',
 				),
 			),
 		));

--- a/includes/class-cocart-init.php
+++ b/includes/class-cocart-init.php
@@ -126,7 +126,7 @@ class CoCart_Rest_API {
 		}
 
 		// Include REST API Controllers.
-		add_action( 'rest_api_init', array( $this, 'rest_api_includes' ), 5 );
+		add_action( 'wp_loaded', array( $this, 'rest_api_includes' ), 5 );
 
 		// Register CoCart REST API routes.
 		add_action( 'rest_api_init', array( $this, 'register_cart_routes' ), 10 );

--- a/includes/class-cocart-init.php
+++ b/includes/class-cocart-init.php
@@ -144,9 +144,7 @@ class CoCart_Rest_API {
 		 * 
 		 * Cart and notice functions are not included during a REST request.
 		 */
-		if ( version_compare( WC_VERSION, '3.6.0', '>=' ) && WC()->is_rest_api_request() == 'wc/' ) {
-			require_once( WC_ABSPATH . 'includes/wc-cart-functions.php' );
-			require_once( WC_ABSPATH . 'includes/wc-notice-functions.php' );
+		if ( version_compare( WC_VERSION, '3.6.0', '>=' ) && WC()->is_rest_api_request() ) {
 
 			if ( null === WC()->session ) {
 				$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );

--- a/includes/class-cocart-init.php
+++ b/includes/class-cocart-init.php
@@ -145,6 +145,8 @@ class CoCart_Rest_API {
 		 * Cart and notice functions are not included during a REST request.
 		 */
 		if ( version_compare( WC_VERSION, '3.6.0', '>=' ) && WC()->is_rest_api_request() ) {
+			require_once( WC_ABSPATH . 'includes/wc-cart-functions.php' );
+			require_once( WC_ABSPATH . 'includes/wc-notice-functions.php' );
 
 			if ( null === WC()->session ) {
 				$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );

--- a/languages/cart-rest-api-for-woocommerce.pot
+++ b/languages/cart-rest-api-for-woocommerce.pot
@@ -1,9 +1,9 @@
 # # Copyright (c) {2019} Sébastien Dumont
 msgid ""
 msgstr ""
-"Project-Id-Version: CoCart 2.0.0-beta.2\n"
+"Project-Id-Version: CoCart 2.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/co-cart/co-cart/issues\n"
-"POT-Creation-Date: 2019-06-18 15:14:53+00:00\n"
+"POT-Creation-Date: 2019-06-25 15:43:26+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -354,8 +354,119 @@ msgstr ""
 msgid "Quantity must be numeric!"
 msgstr ""
 
-#: includes/api/class-cocart-controller.php:465
-#: includes/api/class-cocart-controller.php:524
+#: includes/api/class-cocart-controller.php:466
+#: includes/api/class-cocart-controller.php:526
+#. translators: 1: quantity requested, 2: product name 3: quantity in stock
+msgid ""
+"You cannot add a quantity of %1$s for \"%2$s\" to the cart because there is "
+"not enough stock. - only %3$s remaining!"
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:493
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:317
+msgid "Warning: This product does not exist!"
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:509
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:330
+#. translators: %s: product name
+msgid "You cannot add another \"%s\" to your cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:515
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:336
+msgid "Sorry, this product cannot be purchased."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:521
+#. translators: %s: product name
+msgid "You cannot add \"%s\" to the cart because the product is out of stock."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:538
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:356
+#. translators: 1: quantity in stock, 2: quantity in cart
+msgid ""
+"You cannot add that amount to the cart &mdash; we have %1$s in stock and "
+"you already have %2$s in your cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:552
+msgid "This item can not be added to the cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:582
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:378
+#. translators: %s: product name
+msgid "You cannot add \"%s\" to your cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:600
+msgid "No items in cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:616
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:396
+msgid "Item has been removed from cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:618
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:398
+msgid "Unable to remove item from cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:621
+#: includes/api/class-cocart-controller.php:655
+#: includes/api/class-cocart-controller.php:719
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:401
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:424
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:478
+msgid "Cart item key is required!"
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:650
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:419
+msgid "Item has been restored to the cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:652
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:421
+msgid "Unable to restore item to the cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:707
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:468
+#. translators: 1: product name, 2: new quantity
+msgid "The quantity for \"%1$s\" has increased to \"%2$s\"."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:710
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:470
+#. translators: 1: product name, 2: new quantity
+msgid "The quantity for \"%1$s\" has decreased to \"%2$s\"."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:713
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:472
+#. translators: %s: product name
+msgid "The quantity for \"%s\" has not changed."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:716
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:475
+msgid "Unable to update item quantity in cart."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:734
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:491
+msgid "No items in cart to calculate totals."
+msgstr ""
+
+#: includes/api/class-cocart-controller.php:743
+#: includes/api/wc-v2/class-wc-rest-cart-controller.php:496
+msgid "Cart totals have been calculated."
+msgstr ""
+
 #: includes/api/wc-v2/class-wc-rest-cart-controller.php:291
 #: includes/api/wc-v2/class-wc-rest-cart-controller.php:345
 #. translators: 1: product name 2: quantity in stock
@@ -364,106 +475,10 @@ msgid ""
 "not enough stock (%2$s remaining)."
 msgstr ""
 
-#: includes/api/class-cocart-controller.php:492
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:317
-msgid "Warning: This product does not exist!"
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:508
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:330
-#. translators: %s: product name
-msgid "You cannot add another \"%s\" to your cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:514
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:336
-msgid "Sorry, this product cannot be purchased."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:519
 #: includes/api/wc-v2/class-wc-rest-cart-controller.php:341
 msgid ""
 "You cannot add &quot;%s&quot; to the cart because the product is out of "
 "stock."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:535
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:356
-msgid ""
-"You cannot add that amount to the cart &mdash; we have %1$s in stock and "
-"you already have %2$s in your cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:549
-msgid "This item can not be added to the cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:578
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:378
-msgid "You cannot add \"%s\" to your cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:596
-msgid "No items in cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:612
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:396
-msgid "Item has been removed from cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:614
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:398
-msgid "Unable to remove item from cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:617
-#: includes/api/class-cocart-controller.php:651
-#: includes/api/class-cocart-controller.php:712
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:401
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:424
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:478
-msgid "Cart item key is required!"
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:646
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:419
-msgid "Item has been restored to the cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:648
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:421
-msgid "Unable to restore item to the cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:702
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:468
-msgid "The quantity for \"%1$s\" has increased to \"%2$s\"."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:704
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:470
-msgid "The quantity for \"%1$s\" has decreased to \"%2$s\"."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:706
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:472
-msgid "The quantity for \"%s\" has not changed."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:709
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:475
-msgid "Unable to update item quantity in cart."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:727
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:491
-msgid "No items in cart to calculate totals."
-msgstr ""
-
-#: includes/api/class-cocart-controller.php:736
-#: includes/api/wc-v2/class-wc-rest-cart-controller.php:496
-msgid "Cart totals have been calculated."
 msgstr ""
 
 #: includes/class-cocart-install.php:126

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"title": "CoCart",
 	"name": "cart-rest-api-for-woocommerce",
-	"version": "2.0.0",
+	"version": "2.0.0-rc.1",
 	"private": false,
 	"contributors": [
 		"sebd86"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"title": "CoCart",
 	"name": "cart-rest-api-for-woocommerce",
-	"version": "2.0.0-beta.2",
+	"version": "2.0.0",
 	"private": false,
 	"contributors": [
 		"sebd86"
@@ -19,7 +19,7 @@
 	},
 	"requires": "4.9.8",
 	"requires_php": "5.6",
-	"tested_up_to": "5.2.1",
+	"tested_up_to": "5.2.2",
 	"wc_requires": "3.0.0",
 	"wc_tested_up_to": "3.6.4",
 	"license": "GPL-3.0",

--- a/readme.txt
+++ b/readme.txt
@@ -123,12 +123,15 @@ v2.0.0 is backwards compatible so you can still use the current API. See https:/
 * Changed: Filter and Action Hook names in new API. - See documentation for details.
 * Improved: Complexity of functions for better performance and usage.
 * Tweaked: Added checking for items already in the cart.
+* Tweaked: Check if cart is empty before removing an item.
 * Tweaked: Responses for adding, updating, removing and restoring items to return whole cart if requested.
 * Tweaked: Totals can now return once calculated if requested.
 * Tweaked: Totals now return from session and can be returned pre-formatted if requested. - See documentation for details.
+* Tweaked: New option to refresh cart totals once item has been added.
 * Dev: Added action hooks for getting cart, cart is cleared, item added, item removed and item restored.
 * Dev: Added filter to allow additional checks before the item is added to the cart.
 * Dev: Added filter to apply additional data to return when cart is returned.
 * Dev: Added filter to change the size of the thumbnail returned.
+* Dev: Added new option to return cart raw if requested.
 
 [View the full changelog here](https://github.com/co-cart/co-cart/blob/master/CHANGELOG.md).

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Donate link: https://sebdumont.xyz/donate/
 Requires at least: 4.9.8
 Requires PHP: 5.6
 Tested up to: 5.2.2
-Stable tag: 2.0.0
+Stable tag: 2.0.0-rc.1
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
 License: GPLv3
@@ -113,7 +113,7 @@ v2.0.0 is backwards compatible so you can still use the current API. See https:/
 
 == Changelog ==
 
-= v2.0.0 - 25th June, 2019 =
+= v2.0.0 - ?? ??, 2019 =
 
 * NEW: REST API namespace. CoCart is now an individual API and is no longer nested with WooCommerce's core REST API.
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Tags: woocommerce, cart, endpoint, JSON, rest, api, rest-api
 Donate link: https://sebdumont.xyz/donate/
 Requires at least: 4.9.8
 Requires PHP: 5.6
-Tested up to: 5.2.1
-Stable tag: 1.2.3
+Tested up to: 5.2.2
+Stable tag: 2.0.0
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Donate link: https://sebdumont.xyz/donate/
 Requires at least: 4.9.8
 Requires PHP: 5.6
 Tested up to: 5.2.2
-Stable tag: 2.0.0-rc.1
+Stable tag: 1.2.3
 WC requires at least: 3.0.0
 WC tested up to: 3.6.4
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -109,11 +109,11 @@ Please reach out via the official [support forum on WordPress.org](https://wordp
 
 == Upgrade Notice ==
 
-v2.0.0 is backwards compatible so you can still use the current API. See https://cocart.xyz/cocart-v2-preview/ for more information.
+v2.0.0 is backwards compatible so you can still use the current API. See https://cocart.xyz/cocart-v2-preview/ for more information on the new API.
 
 == Changelog ==
 
-= v2.0.0 =
+= v2.0.0 - 25th June, 2019 =
 
 * NEW: REST API namespace. CoCart is now an individual API and is no longer nested with WooCommerce's core REST API.
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ v2.0.0 is backwards compatible so you can still use the current API. See https:/
 * NEW: Check to see if the cart is set before falling back to the cart in session if one exists.
 * NEW: Get a specific customers cart via their customer ID number. - See documentation for details.
 * NEW: Product title also returns besides just the product name when getting the cart.
+* NEW: Product price also returns when getting the cart.
 * Changed: Filter and Action Hook names in new API. - See documentation for details.
 * Improved: Complexity of functions for better performance and usage.
 * Tweaked: Added checking for items already in the cart.

--- a/readme.txt
+++ b/readme.txt
@@ -44,7 +44,7 @@ Enjoy!
 > - Get Applied Coupons<br />
 > - Get Coupon Discount Total<br />
 > - Get Cart Total Weight<br />
-> - Get Cross Sales<br />
+> - Get Cross Sells<br />
 > - Get and Set Shipping Methods<br />
 > - Get and Set Tax Fees<br />
 > - Calculate Shipping Fees<br />


### PR DESCRIPTION
* WP_Error is no longer in CAPS
* Added notes for translators and tweaked strings.
* Corrected feature mentioned for CoCart Pro.
* New totals override totals instead of another REST Response.
* Added original price of product when getting cart.
* Added more argument descriptions.
* Optional argument corrections.
* Return a response should specified cart item key not exist in cart.
* Tweaked CSS for admin notices.
* Ensure we don't add a variation to the cart directly by variation ID.
* Generate a ID based on product ID, variation ID, variation data, and other cart item data.
* Added new option to refresh cart totals once item has been added.
* Use self get_cart instead of cart class get_cart.
* Added new option to return cart raw if requested.
* Quantity of item increases if item already in cart. Responses improved.
* Removed the need to format quantity value again when checking available stock.
* No need to check if WC endpoint is requested.
* Removed validate_callback for pre-formatted totals.
* Made sure the cart item key parameter name is consistent.
* Return cart parameter is no longer ignored.
* Return cart item contents rather than boolean status.
* Changed hook for loading controllers.
