### PR TITLE
Add rudimentary Product Bundle support

### DIFF
--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -559,8 +559,8 @@ class CoCart_API_Controller {
               // Add the variation to the Bundle Configuration if the variation ID matches one of those provided
               if ( in_array($variation_product['variation_id'], $variation_id_array) ) {
                 $product_bundled_configuration[$bundled_item_id] = array(
-                    'quantity' => $quantity,
                     'variation_id' => $variation_product['variation_id'],
+                    'quantity' => $quantity,
                     'attributes' => $variation_product["attributes"]
                   );
               }
@@ -569,8 +569,8 @@ class CoCart_API_Controller {
           } else {
             if ( $bundled_item->product->get_id() === $product_id ) {
               $product_bundled_configuration[$bundled_item_id] = array(
-                  'quantity' => $quantity,
-                  'product_id' => $bundled_item->product->get_id()
+                  'product_id' => $bundled_item->product->get_id(),
+                  'quantity' => $quantity
                 );
             }
           }
@@ -580,7 +580,7 @@ class CoCart_API_Controller {
 
     // Check each Variation ID provided and add them all to the cart
     foreach ( $variation_id_array as $variation_id ) {
-      $product_data = wc_get_product( $variation_id ? $variation_id : $product_id );
+      $product_data = wc_get_product( $variation_id );
   
       if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
         return new WP_Error( 'cocart_product_does_not_exist', __( 'Warning: This product does not exist!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
@@ -700,7 +700,7 @@ class CoCart_API_Controller {
           return new WP_Error( 'cocart_cannot_add_to_cart', sprintf( __( 'You cannot add "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $bundle_id ), array( 'status' => 500 ) );
         }
       } else {
-        return new WP_Error( 'cocart_cannot_add_to_cart', 'Your bundle ID and/or variation IDs are invalid', array( 'status' => 500 ) );
+        return new WP_Error( 'cocart_cannot_add_to_cart', 'Your bundle ID and/or variation IDs are invalid. Make sure you add all of the items in your bundle.', array( 'status' => 500 ) );
       }
     }
 

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -527,7 +527,11 @@ class CoCart_API_Controller {
       }
     } else {
       $variation_id   = ! isset( $data['variation_id'] ) ? 0 : absint( $data['variation_id'] );
-      $variation_id_array = array($variation_id);
+      if ($variation_id > 0) {
+        $variation_id_array = array($variation_id);
+      } else {
+        $variation_id_array = array();
+      }
     }
     
     $item_added = array();
@@ -580,14 +584,122 @@ class CoCart_API_Controller {
 
     // Check each Variation ID provided and add them all to the cart
     foreach ( $variation_id_array as $variation_id ) {
-      $product_data = wc_get_product( $variation_id );
+        $product_data = wc_get_product( $variation_id );
+    
+        if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
+          return new WP_Error( 'cocart_product_does_not_exist', __( 'Warning: This product does not exist!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+        }
+    
+        // Check if the variation was previously added to cart. Only applicable if not a bundle product
+        if (count($product_bundled_configuration) === 0) {
+          // Generate a ID based on product ID, variation ID, variation data, and other cart item data.
+          $cart_id = WC()->cart->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
+      
+          // Find the cart item key in the existing cart.
+          $cart_item_key = $this->find_product_in_cart( $cart_id );
+      
+          // Force quantity to 1 if sold individually and check for existing item in cart.
+          if ( $product_data->is_sold_individually() ) {
+            $quantity = 1;
+      
+            $cart_contents = $this->get_cart();
+      
+            $found_in_cart = apply_filters( 'cocart_add_to_cart_sold_individually_found_in_cart', $cart_item_key && $cart_contents[ $cart_item_key ]['quantity'] > 0, $product_id, $variation_id, $cart_item_data, $cart_id );
+      
+            if ( $found_in_cart ) {
+              /* translators: %s: product name */
+              return new WP_Error( 'cocart_product_sold_individually', sprintf( __( 'You cannot add another "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
+            }
+          }
+        }
+    
+        // Product is purchasable check.
+        if ( ! $product_data->is_purchasable() ) {
+          return new WP_Error( 'cocart_cannot_be_purchased', __( 'Sorry, this product cannot be purchased.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+        }
+    
+        // Stock check - only check if we're managing stock and backorders are not allowed.
+        if ( ! $product_data->is_in_stock() ) {
+          /* translators: %s: product name */
+          return new WP_Error( 'cocart_product_out_of_stock', sprintf( __( 'You cannot add "%s" to the cart because the product is out of stock.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
+        }
+    
+        if ( ! $product_data->has_enough_stock( $quantity ) ) {
+          /* translators: 1: quantity requested, 2: product name, 3: quantity in stock */
+          return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add a quantity of %1$s for "%2$s" to the cart because there is not enough stock. - only %3$s remaining!', 'cart-rest-api-for-woocommerce' ), $quantity, $product_data->get_name(), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ) ), array( 'status' => 500 ) );
+        }
+    
+        // Stock check - this time accounting for whats already in-cart.
+        if ( $product_data->managing_stock() ) {
+          $products_qty_in_cart = WC()->cart->get_cart_item_quantities();
+    
+          if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
+            /* translators: 1: quantity in stock, 2: quantity in cart */
+            return new WP_Error(
+              'cocart_not_enough_stock_remaining',
+              sprintf(
+                __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'cart-rest-api-for-woocommerce' ),
+                wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ),
+                wc_format_stock_quantity_for_display( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ], $product_data )
+              ),
+              array( 'status' => 500 )
+            );
+          }
+        }
+
+        $response  = apply_filters( 'cocart_ok_to_add_response', '', $product_data );
+        $ok_to_add = apply_filters( 'cocart_ok_to_add', true, $product_data );
+
+        // If it is not OK to add the item, return an error response.
+        if ( ! $ok_to_add ) {
+          $error_msg = empty( $response ) ? __( 'This item can not be added to the cart.', 'cart-rest-api-for-woocommerce' ) : $response;
+    
+          return new WP_Error(
+            'cocart_not_ok_to_add_item', 
+            $error_msg, 
+            array( 'status' => 500 )
+          );
+        }
+
+        $item_added = array();
+        // If not a Product Bundle, try adding this item to the cart
+        if (count($product_bundled_configuration) === 0) {
+          // If cart_item_key is set, then the item is already in the cart so just update the quantity.
+          if ( $cart_item_key ) {
+            $cart_contents = $this->get_cart( array( 'raw' => true ) );
+
+            $new_quantity  = $quantity + $cart_contents[ $cart_item_key ]['quantity'];
+
+            WC()->cart->set_quantity( $cart_item_key, $new_quantity, $data['refresh_totals'] );
+
+            $item_added = WC()->cart->get_cart_item( $cart_item_key );
+          } else {
+            // Add item to cart.
+            $item_key = WC()->cart->add_to_cart( $product_id, $quantity, $variation_id, $variation, $cart_item_data );
+
+            // Return response to added item to cart or return error.
+            if ( $item_key ) {
+
+              $item_added[] = WC()->cart->get_cart_item( $item_key );
+
+              do_action( 'cocart_item_added_to_cart', $item_key, $item_added );
+            } else {
+              /* translators: %s: product name */
+              return new WP_Error( 'cocart_cannot_add_to_cart', sprintf( __( 'You cannot add "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
+            }
+          }
+
+        }
+    }
+
+    // Probably a basic product then
+    if (count($product_bundled_configuration) == 0 && count($variation_id_array) == 0) {
+      if ( 'product' === get_post_type( $product_id ) ) {
+        $product_data = wc_get_product( $product_id );
   
-      if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
-        return new WP_Error( 'cocart_product_does_not_exist', __( 'Warning: This product does not exist!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
-      }
-  
-      // Check if the variation was previously added to cart. Only applicable if not a bundle product
-      if (count($product_bundled_configuration) === 0) {
+        if ( $quantity <= 0 || ! $product_data || 'trash' === $product_data->get_status() ) {
+          return new WP_Error( 'cocart_product_does_not_exist', __( 'Warning: This product does not exist!', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+        }
         // Generate a ID based on product ID, variation ID, variation data, and other cart item data.
         $cart_id = WC()->cart->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
     
@@ -607,59 +719,55 @@ class CoCart_API_Controller {
             return new WP_Error( 'cocart_product_sold_individually', sprintf( __( 'You cannot add another "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
           }
         }
-      }
-  
-      // Product is purchasable check.
-      if ( ! $product_data->is_purchasable() ) {
-        return new WP_Error( 'cocart_cannot_be_purchased', __( 'Sorry, this product cannot be purchased.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
-      }
-  
-      // Stock check - only check if we're managing stock and backorders are not allowed.
-      if ( ! $product_data->is_in_stock() ) {
-        /* translators: %s: product name */
-        return new WP_Error( 'cocart_product_out_of_stock', sprintf( __( 'You cannot add "%s" to the cart because the product is out of stock.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
-      }
-  
-      if ( ! $product_data->has_enough_stock( $quantity ) ) {
-        /* translators: 1: quantity requested, 2: product name, 3: quantity in stock */
-        return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add a quantity of %1$s for "%2$s" to the cart because there is not enough stock. - only %3$s remaining!', 'cart-rest-api-for-woocommerce' ), $quantity, $product_data->get_name(), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ) ), array( 'status' => 500 ) );
-      }
-  
-      // Stock check - this time accounting for whats already in-cart.
-      if ( $product_data->managing_stock() ) {
-        $products_qty_in_cart = WC()->cart->get_cart_item_quantities();
-  
-        if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
-          /* translators: 1: quantity in stock, 2: quantity in cart */
+        // Product is purchasable check.
+        if ( ! $product_data->is_purchasable() ) {
+          return new WP_Error( 'cocart_cannot_be_purchased', __( 'Sorry, this product cannot be purchased.', 'cart-rest-api-for-woocommerce' ), array( 'status' => 500 ) );
+        }
+    
+        // Stock check - only check if we're managing stock and backorders are not allowed.
+        if ( ! $product_data->is_in_stock() ) {
+          /* translators: %s: product name */
+          return new WP_Error( 'cocart_product_out_of_stock', sprintf( __( 'You cannot add "%s" to the cart because the product is out of stock.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
+        }
+    
+        if ( ! $product_data->has_enough_stock( $quantity ) ) {
+          /* translators: 1: quantity requested, 2: product name, 3: quantity in stock */
+          return new WP_Error( 'cocart_not_enough_in_stock', sprintf( __( 'You cannot add a quantity of %1$s for "%2$s" to the cart because there is not enough stock. - only %3$s remaining!', 'cart-rest-api-for-woocommerce' ), $quantity, $product_data->get_name(), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ) ), array( 'status' => 500 ) );
+        }
+    
+        // Stock check - this time accounting for whats already in-cart.
+        if ( $product_data->managing_stock() ) {
+          $products_qty_in_cart = WC()->cart->get_cart_item_quantities();
+    
+          if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
+            /* translators: 1: quantity in stock, 2: quantity in cart */
+            return new WP_Error(
+              'cocart_not_enough_stock_remaining',
+              sprintf(
+                __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'cart-rest-api-for-woocommerce' ),
+                wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ),
+                wc_format_stock_quantity_for_display( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ], $product_data )
+              ),
+              array( 'status' => 500 )
+            );
+          }
+        }
+
+        $response  = apply_filters( 'cocart_ok_to_add_response', '', $product_data );
+        $ok_to_add = apply_filters( 'cocart_ok_to_add', true, $product_data );
+
+        // If it is not OK to add the item, return an error response.
+        if ( ! $ok_to_add ) {
+          $error_msg = empty( $response ) ? __( 'This item can not be added to the cart.', 'cart-rest-api-for-woocommerce' ) : $response;
+    
           return new WP_Error(
-            'cocart_not_enough_stock_remaining',
-            sprintf(
-              __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'cart-rest-api-for-woocommerce' ),
-              wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ),
-              wc_format_stock_quantity_for_display( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ], $product_data )
-            ),
+            'cocart_not_ok_to_add_item', 
+            $error_msg, 
             array( 'status' => 500 )
           );
         }
-      }
 
-      $response  = apply_filters( 'cocart_ok_to_add_response', '', $product_data );
-      $ok_to_add = apply_filters( 'cocart_ok_to_add', true, $product_data );
-
-      // If it is not OK to add the item, return an error response.
-      if ( ! $ok_to_add ) {
-        $error_msg = empty( $response ) ? __( 'This item can not be added to the cart.', 'cart-rest-api-for-woocommerce' ) : $response;
-  
-        return new WP_Error(
-          'cocart_not_ok_to_add_item', 
-          $error_msg, 
-          array( 'status' => 500 )
-        );
-      }
-
-      $item_added = array();
-      // If not a Product Bundle, try adding this item to the cart
-      if (count($product_bundled_configuration) === 0) {
+        $item_added = array();
         // If cart_item_key is set, then the item is already in the cart so just update the quantity.
         if ( $cart_item_key ) {
           $cart_contents = $this->get_cart( array( 'raw' => true ) );
@@ -684,13 +792,11 @@ class CoCart_API_Controller {
             return new WP_Error( 'cocart_cannot_add_to_cart', sprintf( __( 'You cannot add "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $product_data->get_name() ), array( 'status' => 500 ) );
           }
         }
-
       }
     }
 
     // Product Bundle Configuration was constructed. Validate it and add to cart
     if (count($product_bundled_configuration) > 0) {
-
       $bundle_is_valid = WC_PB()->cart->validate_bundle_configuration($bundle_id , $quantity, $product_bundled_configuration);
       if ($bundle_is_valid) {
         $item_key = WC_PB()->cart->add_bundle_to_cart( $bundle_id , $quantity, $product_bundled_configuration, $cart_item_data );

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -560,7 +560,7 @@ class CoCart_API_Controller {
               if ( in_array($variation_product['variation_id'], $variation_id_array) ) {
                 $product_bundled_configuration[$bundled_item_id] = array(
                     'variation_id' => $variation_product['variation_id'],
-                    'quantity' => $quantity,
+                    'quantity' => 1,
                     'attributes' => $variation_product["attributes"]
                   );
               }
@@ -570,7 +570,7 @@ class CoCart_API_Controller {
             if ( $bundled_item->product->get_id() === $product_id ) {
               $product_bundled_configuration[$bundled_item_id] = array(
                   'product_id' => $bundled_item->product->get_id(),
-                  'quantity' => $quantity
+                  'quantity' => 1
                 );
             }
           }

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -697,9 +697,11 @@ class CoCart_API_Controller {
         if ( $item_key ) {
           $item_added[] = WC()->cart->get_cart_item( $item_key );
         } else {
+          error_log("add_to_cart: Product bundle could not be added to cart - ".print_r(wc_get_notices(), true));
           return new WP_Error( 'cocart_cannot_add_to_cart', sprintf( __( 'You cannot add "%s" to your cart.', 'cart-rest-api-for-woocommerce' ), $bundle_id ), array( 'status' => 500 ) );
         }
       } else {
+        error_log("add_to_cart: Product bundle invalid - ".print_r($product_bundled_configuration, true));
         return new WP_Error( 'cocart_cannot_add_to_cart', 'Your bundle ID and/or variation IDs are invalid. Make sure you add all of the items in your bundle.', array( 'status' => 500 ) );
       }
     }


### PR DESCRIPTION
Hi seb

We had the need to add Product Bundle support to yout plugin. There are some issues with this at the moment:

- You need to be able to supply multiple ID's. A product bundle might or might not require all items in the bundle to be added at once, so this is a required change
- To fix this, we allowed `$data[variation_id]`JSON parameter to be an array (in our case, the Product Bundles only consisted of multiple variable products). Ideally, the same should be done for `$data[product_id]`
- This might be an opportunity to consider adding support for adding multiple of regular products to a cart in a single API call

I know this pull request is probably not ready to merged. It does not break any backwards compatibility, but it also does not fully flesh out the feature yet. But it's here if you want to take a look at it one day!