### PR TITLE
Optimizing load cart from session

### DIFF
--- a/includes/class-cocart-session.php
+++ b/includes/class-cocart-session.php
@@ -160,9 +160,6 @@ class CoCart_API_Session {
 		// Get the cart currently in session if any.
 		$cart_in_session = WC()->session->get( 'cart', null );
 
-		// Get the cart currently in session if any.
-		$cart_in_session = WC()->session->get( 'cart', null );
-
 		$new_cart = array();
 
 		$new_cart['cart']                       = maybe_unserialize( $stored_cart['cart'] );

--- a/includes/class-cocart-session.php
+++ b/includes/class-cocart-session.php
@@ -142,20 +142,23 @@ class CoCart_API_Session {
 			$redirect = true;
 		}
 
-		// Check if the cart session exists.
-		if ( ! $this->is_cart_saved( $cart_key ) ) {
-			CoCart_Logger::log( sprintf( __( 'Unable to find cart for: %s', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'info' );
-
-			if ( $notify_customer ) {
-				wc_add_notice( __( 'Sorry but this cart has expired!', 'cart-rest-api-for-woocommerce' ), 'error' );
-			}
-
-			return;
-		}
-
 		// Get the cart in the database.
 		$handler     = new CoCart_Session_Handler();
 		$stored_cart = $handler->get_cart( $cart_key );
+			  if ( empty( $stored_cart ) ) {
+				  CoCart_Logger::log( sprintf( __( 'Unable to find cart for:
+		%s', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'info' );
+
+				  if ( $notify_customer ) {
+					  wc_add_notice( __( 'Sorry but this cart has expired!',
+		'cart-rest-api-for-woocommerce' ), 'error' );
+				  }
+
+				  return;
+			  }
+
+		// Get the cart currently in session if any.
+		$cart_in_session = WC()->session->get( 'cart', null );
 
 		// Get the cart currently in session if any.
 		$cart_in_session = WC()->session->get( 'cart', null );


### PR DESCRIPTION
### Description
Replaced $this in the static load_cart function
$this->is_cart_saved is removed and replaced with the same code that was in the function anyway.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I used is on my website to fix an error i got with php 7.4

### Checklist:
- [x ] My code is tested
- [ x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
