### PR TITLE
Possibility to get back the cart key in the response

### DIFF
--- a/includes/api/class-cocart-add-item-controller.php
+++ b/includes/api/class-cocart-add-item-controller.php
@@ -104,7 +104,15 @@ class CoCart_Add_Item_Controller extends CoCart_API_Controller {
 			}
 
 			if ( ! empty( $response ) ) {
-				return new WP_REST_Response( $response, 200 );
+				$payload = $response;
+
+				$cart_key_in_body = !empty($data['cart_key_in_body']) ? $data['cart_key_in_body'] : null;
+				if($cart_key_in_body) {
+					$cookie = WC()->session->get_session_cookie();
+					$payload['cart_key'] = $cookie;
+				}
+
+				return new WP_REST_Response( $payload, 200 );
 			}
 		}
 	} // END add_to_cart()
@@ -323,6 +331,11 @@ class CoCart_Add_Item_Controller extends CoCart_API_Controller {
 				'validate_callback' => function( $value, $request, $param ) {
 					return is_numeric( $value );
 				}
+			),
+			'cart_key_in_body' => array(
+				'description' => __('Returns the WC session cookie value in the payload body as a complement to the session cookie', 'cart-rest-api-for-woocommerce'),
+				'type' => 'boolean',
+				'default' => false
 			),
 			'variation_id' => array(
 				'description'       => __( 'Unique identifier for the variation.', 'cart-rest-api-for-woocommerce' ),

--- a/includes/api/class-cocart-add-item-controller.php
+++ b/includes/api/class-cocart-add-item-controller.php
@@ -109,7 +109,7 @@ class CoCart_Add_Item_Controller extends CoCart_API_Controller {
 				$cart_key_in_body = !empty($data['cart_key_in_body']) ? $data['cart_key_in_body'] : null;
 				if($cart_key_in_body) {
 					$cookie = WC()->session->get_session_cookie();
-					$payload['cart_key'] = $cookie;
+					$payload['cart_key'] = $cookie[3]; // Represents the cart hash
 				}
 
 				return new WP_REST_Response( $payload, 200 );

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -110,7 +110,15 @@ class CoCart_API_Controller {
 			return $cart_contents;
 		}
 
-		return new WP_REST_Response( $cart_contents, 200 );
+		$payload = $cart_contents;
+
+		$cart_key_in_body = !empty($data['cart_key_in_body']) ? $data['cart_key_in_body'] : null;
+		if($cart_key_in_body) {
+			$cookie = WC()->session->get_session_cookie();
+			$payload['cart_key'] = $cookie;
+		}
+
+		return new WP_REST_Response( $payload, 200 );
 	} // END get_cart()
 
 	/**
@@ -776,9 +784,9 @@ class CoCart_API_Controller {
 	} // END find_product_in_cart()
 
 	/**
-	 * Checks if the product in the cart has enough stock 
+	 * Checks if the product in the cart has enough stock
 	 * before updating the quantity.
-	 * 
+	 *
 	 * @access  protected
 	 * @since   1.0.6
 	 * @version 2.1.2
@@ -804,7 +812,7 @@ class CoCart_API_Controller {
 	} // END has_enough_stock()
 
 	/**
-	 * Look's up an item in the cart and returns it's data 
+	 * Look's up an item in the cart and returns it's data
 	 * based on the condition it is being returned for.
 	 *
 	 * @access  public
@@ -967,6 +975,11 @@ class CoCart_API_Controller {
 			'cart_key' => array(
 				'description' => __( 'Unique identifier for the cart/customer.', 'cart-rest-api-for-woocommerce' ),
 				'type'        => 'string',
+			),
+			'cart_key_in_body' => array(
+				'description' => __('Returns the WC session cookie value in the payload body as a complement to the session cookie', 'cart-rest-api-for-woocommerce'),
+				'type' => 'boolean',
+				'default' => false
 			),
 			'thumb' => array(
 				'description' => __( 'Returns the URL of the product image thumbnail.', 'cart-rest-api-for-woocommerce' ),

--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -115,7 +115,7 @@ class CoCart_API_Controller {
 		$cart_key_in_body = !empty($data['cart_key_in_body']) ? $data['cart_key_in_body'] : null;
 		if($cart_key_in_body) {
 			$cookie = WC()->session->get_session_cookie();
-			$payload['cart_key'] = $cookie;
+			$payload['cart_key'] = $cookie[3]; // Represents the cart hash
 		}
 
 		return new WP_REST_Response( $payload, 200 );


### PR DESCRIPTION
### Description
I've made minor adjustments to enable the possibility to get back the cart key hash for the Woocommerce session in the payload of the response body as a complement to handling response cookies on the client-side.

### Screenshots
Not relevant.

### Types of changes
New feature

### How has this been tested?
Tested with and without the flag activated for add_item and get_cart-endpoints

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
