### PR TITLE
Fix CORS requests by replacing wildcard * with specific origin in Acc…

### DIFF
--- a/includes/class-cocart-init.php
+++ b/includes/class-cocart-init.php
@@ -376,7 +376,7 @@ class CoCart_Rest_API {
 	 * @return bool
 	 */
 	public function cors_headers( $served, $result, $request, $server ) {
-		header( 'Access-Control-Allow-Origin: *' );
+        header( 'Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN'] );
 		header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE' );
 		header( 'Access-Control-Allow-Credentials: true' );
 		header( 'Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With' );


### PR DESCRIPTION
…ess-Control-Allow-Origin

### Description
Fixes CORS requests. Setting Access-Control-Allow-Origin to wildcard * is not compatible with including credentials (cookies) in Ajax requests. To include cookies in a cors request the Access-Control-Allow-Origin must exactly match the origin of the request.

### Screenshots
N/A

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
Tested on my test server.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
