### PR TITLE
Version check before use of E_WC_ADMIN_NOTE_MARKETING const

### DIFF
--- a/includes/admin/notes/class-cocart-wc-admin-note-do-with-products.php
+++ b/includes/admin/notes/class-cocart-wc-admin-note-do-with-products.php
@@ -79,11 +79,10 @@ class CoCart_WC_Admin_Do_With_Products_Note extends CoCart_WC_Admin_Notes {
 	 * @return array
 	 */
 	public static function get_note_args() {
-		global $woocommerce;
 		$args = array(
 			'title'   => sprintf( __( '6 things you can do %s', 'cart-rest-api-for-woocommerce' ), 'CoCart Products' ),
 			'content' => sprintf( __( 'Fetching your products via the REST API should be easy with no authentication issues. Learn more about the six things you can do with %1$s to help your development with %2$s.', 'cart-rest-api-for-woocommerce' ), 'CoCart Products', 'CoCart' ),
-			'type'    => ( version_compare( $woocommerce->version, '4.3.0', ">=" ) ) ? Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING : Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+			'type'    => ( version_compare( WC_VERSION, '4.3.0', ">=" ) ) ? Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING : Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 			'layout'  => 'thumbnail',
 			'image'   => 'https://cocart.xyz/wp-content/uploads/2020/03/rwmibqmoxry-128x214.jpg',
 			'name'    => self::NOTE_NAME,

--- a/includes/admin/notes/class-cocart-wc-admin-note-do-with-products.php
+++ b/includes/admin/notes/class-cocart-wc-admin-note-do-with-products.php
@@ -79,10 +79,11 @@ class CoCart_WC_Admin_Do_With_Products_Note extends CoCart_WC_Admin_Notes {
 	 * @return array
 	 */
 	public static function get_note_args() {
+		global $woocommerce;
 		$args = array(
 			'title'   => sprintf( __( '6 things you can do %s', 'cart-rest-api-for-woocommerce' ), 'CoCart Products' ),
 			'content' => sprintf( __( 'Fetching your products via the REST API should be easy with no authentication issues. Learn more about the six things you can do with %1$s to help your development with %2$s.', 'cart-rest-api-for-woocommerce' ), 'CoCart Products', 'CoCart' ),
-			'type'    => Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING,
+			'type'    => ( version_compare( $woocommerce->version, '4.3.0', ">=" ) ) ? Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING : Automattic\WooCommerce\Admin\Notes\WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 			'layout'  => 'thumbnail',
 			'image'   => 'https://cocart.xyz/wp-content/uploads/2020/03/rwmibqmoxry-128x214.jpg',
 			'name'    => self::NOTE_NAME,


### PR DESCRIPTION
Addresses #146 - reporter was running WooCommerce 4.2.0 per the system status report.

The `E_WC_ADMIN_NOTE_MARKETING` constant was added in WC 4.3.0. If site is using something less than 4.3.0, default back to use of older `E_WC_ADMIN_NOTE_INFORMATIONAL` value.