### PR TITLE
Update class-cocart-controller.php

### DIFF
--- a/includes/api/class-cocart-controller.php
+++ b/includes/api/class-cocart-controller.php
@@ -103,6 +103,8 @@ class CoCart_API_Controller {
 	 * @return  array|WP_REST_Response
 	 */
 	public function get_cart( $data = array(), $cart_item_key = '' ) {
+		do_action( 'woocommerce_check_cart_items' );
+		
 		$cart_contents = $this->get_cart_contents( $data, $cart_item_key );
 
 		do_action( 'cocart_get_cart', $cart_contents );


### PR DESCRIPTION
Should fix cart notices, as of now no cart notices are being returned (when item is not in stock etc...)

` "notices": {
    "error": [
      "Sorry, we do not have enough \"Product Name\" in stock to fulfill your order (1 available). We apologize for any inconvenience caused."
    ]
  },`