### PR TITLE
Reduce expiration time for shopping cart

### DIFF
--- a/includes/class-cocart-session-handler.php
+++ b/includes/class-cocart-session-handler.php
@@ -301,8 +301,8 @@ class CoCart_Session_Handler extends WC_Session {
 	 * @access public
 	 */
 	public function set_cart_expiration() {
-		$this->_cart_expiring   = time() + intval( apply_filters( 'cocart_cart_expiring', DAY_IN_SECONDS * 29 ) ); // 29 Days.
-		$this->_cart_expiration = time() + intval( apply_filters( 'cocart_cart_expiration', DAY_IN_SECONDS * 30 ) ); // 30 Days.
+		$this->_cart_expiring   = time() + intval( apply_filters( 'cocart_cart_expiring', DAY_IN_SECONDS * 6 ) ); // 6 Days.
+		$this->_cart_expiration = time() + intval( apply_filters( 'cocart_cart_expiration', DAY_IN_SECONDS * 7 ) ); // 7 Days.
 	} // END set_cart_expiration()
 
 	/**


### PR DESCRIPTION
### Description
Reduce `expiring` to `6` days and `expiration` to `7` days in `/includes/class-cocart-session-handler.php`.
I made this contribution as part of Hacktoberfest.

### Types of changes
Enhancement, related to Issue #154 

### How has this been tested?
Checked that changed values are properly set in session.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->

Closes #154 
