### PR TITLE
Added header "Access-Control-Expose-Headers" to allow `X-COCART-API` to be exposed

### DIFF
--- a/includes/class-cocart-authentication.php
+++ b/includes/class-cocart-authentication.php
@@ -144,7 +144,7 @@ if ( ! class_exists( 'CoCart_Authentication' ) ) {
 			header( 'Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE' );
 			header( 'Access-Control-Allow-Credentials: true' );
 			header( 'Access-Control-Allow-Headers: Authorization, Content-Type, X-Requested-With' );
-
+			header('Access-Control-Expose-Headers: X-CoCart-API'); 
 			return $served;
 		} // END cors_headers()
 


### PR DESCRIPTION
### Description
The cors did not expose the header X-CoCart-API - this is the only way to get the key if accessing via a frontend.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
