### PR TITLE
Update class-cocart-item-controller.php

### DIFF
--- a/includes/api/class-cocart-item-controller.php
+++ b/includes/api/class-cocart-item-controller.php
@@ -335,7 +335,7 @@ class CoCart_Item_Controller extends CoCart_API_Controller {
 
 					$product_data = wc_get_product( $variation_id ? $variation_id : $product_id );
 
-					if ( $quantity != $new_data['quantity'] ) {
+					if ( $quantity != $current_data['quantity'] ) {
 						do_action( 'cocart_item_quantity_changed', $cart_item_key, $new_data );
 
 						/**


### PR DESCRIPTION
**cocart_item_quantity_changed** action not being called correctly after updating a cart item's quantity, referenced to new_data instead of current_data quantity value.