### PR TITLE
New Feature: Add meta data for shipping rates

### DIFF
--- a/includes/api/class-cocart-cart-controller.php
+++ b/includes/api/class-cocart-cart-controller.php
@@ -1346,6 +1346,7 @@ class CoCart_Cart_V2_Controller extends CoCart_API_Controller {
 						'html'          => html_entity_decode( strip_tags( wc_cart_totals_shipping_method_label( $method ) ) ),
 						'taxes'         => $method->taxes,
 						'chosen_method' => ( $chosen_method === $key ),
+						'meta_data'  	=> $method->get_meta_data(),
 					);
 				}
 			}


### PR DESCRIPTION
### Description
Add a new key in the rates object to put the metadata that previously you have been able to add in the calculate_shipping rates. There is no side effect, if the rate no contain any metadata will return an empty array.

### Screenshots
Without any meta_data
![Without any meta_data](https://user-images.githubusercontent.com/5048928/121865817-ab24b080-ccfe-11eb-93b7-2566d9623c2d.png)
With meta_data
![With meta_data](https://user-images.githubusercontent.com/5048928/121866288-13739200-ccff-11eb-9718-01d801aab699.png)


### Types of changes
New feature (non-breaking change which adds functionality) 
Shipping: Rate object with meta_data

### How has this been tested?
WP 5.7.1
WooCommerce 5.3.0
CoCart Lite 3.0.5
Added a custom shipping method with some calculation rates and added a few keys to increase the verbosity of the shipping method in the frontend. 
There is no impact in the Storefront theme and it's present in the CoCart Rest API without breaking any existing functionality.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
