### PR TITLE
custom responses after adding or removing product from cart

### DIFF
--- a/includes/api/class-cocart-add-item-controller.php
+++ b/includes/api/class-cocart-add-item-controller.php
@@ -124,6 +124,7 @@ class CoCart_Add_Item_v2_Controller extends CoCart_Add_Item_Controller {
 					$response = $controller->get_item( $was_added_to_cart['data'], $was_added_to_cart, $was_added_to_cart['key'], true );
 				} else {
 					$response = $controller->get_cart_contents( $request );
+					$response = apply_filters( 'cocart_add_to_cart_custom_message', $response, $was_added_to_cart );
 				}
 
 				return CoCart_Response::get_response( $response, $this->namespace, $this->rest_base );

--- a/includes/api/class-cocart-remove-item-controller.php
+++ b/includes/api/class-cocart-remove-item-controller.php
@@ -150,6 +150,7 @@ class CoCart_Remove_Item_v2_Controller extends CoCart_Item_Controller {
 				$controller->get_cart_instance()->calculate_totals();
 
 				$response = $controller->get_cart_contents( $request );
+				$response = apply_filters( 'cocart_remove_from_cart_custom_message', $response);
 
 				/* translators: %s: Item name. */
 				$message = sprintf( __( '%s has been removed from cart.', 'cart-rest-api-for-woocommerce' ), $item_removed_title );


### PR DESCRIPTION
### Description
custom responses after adding or removing product from cart

### Types of changes
new feature - i added two new hooks:
`cocart_add_to_cart_custom_message
cocart_remove_from_cart_custom_message`

### How has this been tested?
I tested this in my own wordpress project

### Checklist:
- [x] My code is tested
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
