### PR TITLE
Allow registered user to load guest cart

### DIFF
--- a/includes/class-cocart-session.php
+++ b/includes/class-cocart-session.php
@@ -113,28 +113,28 @@ class CoCart_API_Session {
 
 			wc_nocache_headers();
 
-            // Check the cart doesn't belong to a registered user - only guest carts should be loadable from session
-            $user = get_user_by( 'id', $cart_key );
+			// Check the cart doesn't belong to a registered user - only guest carts should be loadable from session
+			$user = get_user_by( 'id', $cart_key );
 
-            // If the user exists, the cart key is for a registered user so we should just return
-            if ( ! empty( $user ) ) {
-                if ( is_user_logged_in() ) {
-                    $current_user = wp_get_current_user();
-                    $user_id      = $current_user->ID;
+			// If the user exists, the cart key is for a registered user so we should just return
+			if ( ! empty( $user ) ) {
+				if ( is_user_logged_in() ) {
+					$current_user = wp_get_current_user();
+					$user_id      = $current_user->ID;
 
-                    // Compare the user ID with the cart key.
-                    if ( $user_id === $cart_key ) {
-                        /* translators: %s: cart key */
-                        CoCart_Logger::log( sprintf( __( 'Cart key "%s" is already loaded as the currently logged in user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
-                    } else {
-                        /* translators: %s: cart key */
-                        CoCart_Logger::log( sprintf( __( 'Customer is logged in as a different user. Cart key "%s" cannot be loaded into session for a different user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
-                    }
-                } else {
-                    CoCart_Logger::log( __( 'Cart key is recognised as a registered user on site. Cannot be loaded into session for a guest.', 'cart-rest-api-for-woocommerce' ), 'error' );
-                }
-                return;
-            }
+					// Compare the user ID with the cart key.
+					if ( $user_id === $cart_key ) {
+						/* translators: %s: cart key */
+						CoCart_Logger::log( sprintf( __( 'Cart key "%s" is already loaded as the currently logged in user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
+					} else {
+						/* translators: %s: cart key */
+						CoCart_Logger::log( sprintf( __( 'Customer is logged in as a different user. Cart key "%s" cannot be loaded into session for a different user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
+					}
+				} else {
+					CoCart_Logger::log( __( 'Cart key is recognised as a registered user on site. Cannot be loaded into session for a guest.', 'cart-rest-api-for-woocommerce' ), 'error' );
+				}
+				return;
+			}
 
 			// At this point, the cart should load into session with no issues as we have passed verification.
 

--- a/includes/class-cocart-session.php
+++ b/includes/class-cocart-session.php
@@ -113,30 +113,28 @@ class CoCart_API_Session {
 
 			wc_nocache_headers();
 
-			// Check the user is logged in. If true a different cart cannot be loaded so just return.
-			if ( is_user_logged_in() ) {
-				$current_user = wp_get_current_user();
-				$user_id      = $current_user->ID;
+            // Check the cart doesn't belong to a registered user - only guest carts should be loadable from session
+            $user = get_user_by( 'id', $cart_key );
 
-				// Compare the user ID with the cart key.
-				if ( $user_id === $cart_key ) {
-					/* translators: %s: cart key */
-					CoCart_Logger::log( sprintf( __( 'Cart key "%s" is already loaded as the user is logged in.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'errro' );
-				} else {
-					/* translators: %s: cart key */
-					CoCart_Logger::log( sprintf( __( 'Customer is already logged in. Cart key "%s" cannot be loaded into session.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
-				}
-				return;
-			} else {
-				// If user is not logged in, check that the cart key does not belong to a user registered.
-				$user = get_user_by( 'id', $cart_key );
+            // If the user exists, the cart key is for a registered user so we should just return
+            if ( ! empty( $user ) ) {
+                if ( is_user_logged_in() ) {
+                    $current_user = wp_get_current_user();
+                    $user_id      = $current_user->ID;
 
-				// If the user exists then just return.
-				if ( ! empty( $user ) ) {
-					CoCart_Logger::log( __( 'Cart key is recognised as a registered user on site. Cannot be loaded into session.', 'cart-rest-api-for-woocommerce' ), 'error' );
-					return;
-				}
-			}
+                    // Compare the user ID with the cart key.
+                    if ( $user_id === $cart_key ) {
+                        /* translators: %s: cart key */
+                        CoCart_Logger::log( sprintf( __( 'Cart key "%s" is already loaded as the currently logged in user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
+                    } else {
+                        /* translators: %s: cart key */
+                        CoCart_Logger::log( sprintf( __( 'Customer is logged in as a different user. Cart key "%s" cannot be loaded into session for a different user.', 'cart-rest-api-for-woocommerce' ), $cart_key ), 'error' );
+                    }
+                } else {
+                    CoCart_Logger::log( __( 'Cart key is recognised as a registered user on site. Cannot be loaded into session for a guest.', 'cart-rest-api-for-woocommerce' ), 'error' );
+                }
+                return;
+            }
 
 			// At this point, the cart should load into session with no issues as we have passed verification.
 


### PR DESCRIPTION
### Description
Refactored the user validation in `load_cart_action()` to allow a registered user to load a guest session. Before, the logic only allowed guest users to load guest sessions, but prohibited registered users from loading anything. Now, both guest users and registered users can load a guest session, but it retains the same security restriction that neither can load a session for a registered user. I think this change aligns with how the documentation says the Load From Session feature is supposed to work.

### Types of changes
New feature - allows registered/logged-in user to load a guest session, the same way a guest user does

### How has this been tested?
* Generated guest cart keys and verified that they loaded as expected using cocart-load-cart in the webview, using both a guest and a registered/logged-in user
* Attempted to load cart_keys belonging to a registered user and verified it did not load the cart, either for guests or a different registered user

### Checklist:
- [X ] My code is tested
- [X ] My code has proper inline documentation
