### PR TITLE
fix clearing cart

### DIFF
--- a/includes/api/cocart/v2/cart/class-cocart-clear-cart-controller.php
+++ b/includes/api/cocart/v2/cart/class-cocart-clear-cart-controller.php
@@ -79,6 +79,7 @@ class CoCart_Clear_Cart_v2_Controller extends CoCart_Cart_V2_Controller {
 
 			// Clear cart.
 			WC()->cart->cart_contents = array();
+			WC()->session->cart = array();
 
 			// Clear removed items if not kept.
 			if ( ! $request['keep_removed_items'] ) {


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Fix clearing items from cart.
`WC()->cart->cart_contents = array()` empty array though I have products in cart
`WC()->session->cart` products in cart

### Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I tested this changes with:
-adding to cart
-removing from cart
-merge cart
-clear cart 

All operations work.

### Checklist:
- [ ] My code is tested
