### PR TITLE
Fix typos

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -124,7 +124,7 @@ add_filter( 'cocart_is_allowed_to_override_price', function() {
 });
 ```
 
-To help with hijacking the price, a salt key can be set via the new settings page or by defining a new constant `COCART_SALT_KEY` in your `wp-config.php` file. This can be anything you wish it to be as long as it's not rememberable. It will be encrypted later with **md5** when validated. Once a salt key is set, any request to add item/s to the cart with a new price CoCart will check if the salt key was also passed along. If the salt key does not match then the price will remain the same.
+To help with hijacking the price, a salt key can be set via the new settings page or by defining a new constant `COCART_SALT_KEY` in your `wp-config.php` file. This can be anything you wish it to be as long as it's not memorable. It will be encrypted later with **md5** when validated. Once a salt key is set, any request to add item/s to the cart with a new price CoCart will check if the salt key was also passed along. If the salt key does not match then the price will remain the same.
 
 ### FAQ
 

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -20,7 +20,7 @@ PROJECT_PATH=$(pwd)
 BUILD_PATH="${PROJECT_PATH}/plugins"
 DEST_PATH="$BUILD_PATH/$PLUGIN_SLUG"
 
-output 3 "Installing dependancies";
+output 3 "Installing dependencies";
 npm install
 
 output 3 "Installing packages";

--- a/bin/ready-to-release.sh
+++ b/bin/ready-to-release.sh
@@ -57,6 +57,6 @@ find ./ -name "composer.lock" -type f -delete
 find ./ -name "README.md" -type f -delete
 output 2 "Done!"
 
-output 4 "Returning to developement folder."
+output 4 "Returning to development folder."
 cd -
 output 2 "CoCart can now be activated from your WordPress dashboard."

--- a/bin/ready-to-test.sh
+++ b/bin/ready-to-test.sh
@@ -52,6 +52,6 @@ find ./../cocart -name ".github" -type d -exec rm -rf {} +
 find ./../cocart -name "README.md" -type f -delete
 output 2 "Done!"
 
-output 4 "Returning to developement folder."
+output 4 "Returning to development folder."
 cd -
 output 2 "CoCart can now be activated from your WordPress dashboard."


### PR DESCRIPTION
### Description
Found misspellings with `typos`.

Affects shell scripts and docs.
