### PR TITLE
Fixed Access-Control-Allow-Credentials value being rendered out as 1

### DIFF
--- a/includes/class-cocart-authentication.php
+++ b/includes/class-cocart-authentication.php
@@ -373,7 +373,7 @@ if ( ! class_exists( 'CoCart_Authentication' ) ) {
 				if ( method_exists( $server, 'send_header' ) ) {
 					$server->send_header( 'Access-Control-Allow-Origin', apply_filters( 'cocart_allow_origin', $origin ) );
 					$server->send_header( 'Access-Control-Allow-Methods', 'OPTIONS, GET, POST, PUT, PATCH, DELETE' );
-					$server->send_header( 'Access-Control-Allow-Credentials', true );
+					$server->send_header( 'Access-Control-Allow-Credentials', 'true' );
 					$server->send_header( 'Access-Control-Allow-Headers', implode( ', ', $allow_headers ) );
 					$server->send_header( 'Access-Control-Expose-Headers', implode( ', ', $expose_headers ) );
 				}


### PR DESCRIPTION
### Description
As per the issue I submitted, I fixed a bug with the Access-Control-Allow-Credentials header being wrongly set.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
