### PR TITLE
Fixed fatal in load_cart_action when keep-cart is set on an empty stored cart

### DIFF
--- a/includes/classes/class-cocart-session.php
+++ b/includes/classes/class-cocart-session.php
@@ -238,7 +238,9 @@ class CoCart_Load_Cart {
 			cocart_do_deprecated_action( 'cocart_load_cart_override', '4.6.4' );
 
 			// Check if we are keeping the cart currently set via the web.
-			if ( ! empty( $_GET['keep-cart'] ) && is_bool( $_GET['keep-cart'] ) !== true ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$keep_cart = ! empty( $_GET['keep-cart'] ) && filter_var( wp_unslash( $_GET['keep-cart'] ), FILTER_VALIDATE_BOOLEAN ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( $keep_cart ) {
 				$new_cart_content = array_merge( $new_cart['cart'], maybe_unserialize( $cart_in_session ) );
 				/**
 				 * Filter allows you to adjust the merged cart contents.


### PR DESCRIPTION
`CoCart_Load_Cart::load_cart_action()` throws a fatal `TypeError` on checkout when the URL contains `cocart-load-cart` and `keep-cart=false` and the referenced stored cart no longer has a `cart` sub-key (e.g. items cleared after a completed order, but the row hasn't expired).

Two bugs at the same location (`includes/classes/class-cocart-session.php`, lines 118-119): 

1. `is_bool( $_GET['keep-cart'] ) !== true` is meaningless — `$_GET` values are always strings, so `is_bool()` is always `false` and the check is always true. The guard degenerates to `! empty( $_GET['keep-cart'] )`, meaning the merge branch fires for any non-empty value including `"false"` — the opposite of intent.
2. `array_merge( $new_cart['cart'], ... )` doesn't account for `$new_cart['cart']` being `null`, which is explicitly permitted four lines above (`isset( $requested_cart['cart']) ? ... : null`). On PHP 8 this throws `TypeError: array_merge(): Argument #1 must be of type array, null given`. 

```
[07-Apr-2026 08:13:40 UTC] PHP Fatal error:  Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /var/www/html/wp-content/plugins/cart-rest-api-for-woocommerce/includes/classes/class-cocart-session.php:242
Stack trace:
#0 /var/www/html/wp-content/plugins/cart-rest-api-for-woocommerce/includes/classes/class-cocart-session.php(242): array_merge(NULL, Array)
#1 /var/www/html/wp-includes/class-wp-hook.php(341): CoCart_Load_Cart::load_cart_action('')
#2 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(NULL, Array)
#3 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#4 /var/www/html/wp-content/plugins/woocommerce/includes/class-wc-cart-session.php(104): do_action('woocommerce_loa...')
#5 /var/www/html/wp-includes/class-wp-hook.php(341): WC_Cart_Session->get_cart_from_session('')
#6 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters(NULL, Array)
#7 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action(Array)
#8 /var/www/html/wp-settings.php(764): do_action('wp_loaded')
#9 /var/www/html/wp-config.php(139): require_once('/var/www/html/w...')
#10 /var/www/html/wp-load.php(50): require_once('/var/www/html/w...')
#11 /var/www/html/wp-blog-header.php(13): require_once('/var/www/html/w...')
#12 /var/www/html/index.php(17): require('/var/www/html/w...')
#13 {main}
```

**Fix**: parse `keep-cart` with `filter_var( ..., FILTER_VALIDATE_BOOLEAN )` so truthy values like `"1"`/`"true"`/`"yes"` enter the merge branch and falsy ones (`"0"`/`"false"`/`"no"`/missing) skip it; defensively coerce `$new_cart['cart']` to an empty array before `array_merge` when it's not an array. Five lines added, two removed.

Note: there is a deliberate behavior change worth flagging — `keep-cart=0`/`false`/`no` now correctly mean "don't merge", which previously (and unintentionally) entered the merge branch. Truthy values behave unchanged. 

### Screenshots

N/A — backend fatal error, not visual.
 
### Types of changes

Bug fix (non-breaking change which fixes an issue).

### How has this been tested?

Reproduced and verified locally on Wordpress 6.9.4, CoCart 4.8.3, WooCommerce 10.6.2, PHP 8.4 in a podman dev environment:
1. Headless frontend redirects to `/checkout/?cocart-load-cart=t_xxx&keep-cart=false&...`
2. Cart loads, customer completes payment, reaches the thank-you page 
3. Customer presses **Back** in the browser → before patch: WSOD with `Fatal error: array_merge(): Argument #1 must be of type array, null given in .../class-cocart-session.php:242`.
   After patch: checkout page renders normally with 
empty cart, no fatal. 
1. Regression check on the regular override flow (fresh cart loaded from frontend with `keep-cart=false`) — still works as expected, items appear in `review-order`, order can be placed.

`./vendor/bin/phpcs --standard=phpcs.xml includes/classes/class-cocart-session.php` reports the same one pre-existing warning before and after the patch (`CoCart.Commenting.CommentHooks.MissingSinceComment` on an unrelated hook); no new violations introduced.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation 
- [ ] I've included any necessary tests 
- [ ] I've included developer documentation
- [ ] I've added proper labels to this pull request